### PR TITLE
Use full namespace for importing of Cache class

### DIFF
--- a/src/AnalyticsReports.php
+++ b/src/AnalyticsReports.php
@@ -4,6 +4,7 @@ namespace Spatie\AnalyticsReports;
 
 use Cache;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Collection;
 use Thujohn\Analytics\Analytics;
 


### PR DESCRIPTION
Always use the full namespace.